### PR TITLE
Add QoE (Stats for Nerds) logging for YouTube and Twitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,8 @@ downloaded_files/
 google_creds.json
 
 google_key.json
+
+# QoE / Stats-for-Nerds logs (generated at runtime)
+*_stats.jsonl
+netgent_video_stats.jsonl
+run.log

--- a/README.md
+++ b/README.md
@@ -148,3 +148,67 @@ results = agent.run(state_prompts=[], state_repository=your_saved_repo)
 See the example scripts and CLI source for more patterns, and customize credentials or cache directory as needed.
 
 For API key configuration details, refer to [API_KEYS.md](API_KEYS.md).
+
+## QoE Logging (Stats for Nerds)
+
+NetGent can record video Quality-of-Experience (QoE) metrics throughout a streaming session, the same data that YouTube exposes via its "Stats for Nerds" overlay. This is useful for correlating the network traffic NetGent generates with the player's perceived playback quality.
+
+Instead of scraping the fragile right-click overlay, the logger reads the metrics directly from the player via JavaScript and samples them on a background thread, writing one JSON object per sample to a JSONL file.
+
+### Supported platforms
+
+| Platform | Source | Captured metrics (when playing) |
+|----------|--------|---------------------------------|
+| **YouTube** | `movie_player.getStatsForNerds()` + `<video>` | resolution, codecs, bandwidth, buffer health, dropped/total frames, network activity, live latency, video id/title/author |
+| **Twitch** | `HTMLVideoElement` API | resolution, dropped/total frames, buffer-ahead seconds, playback rate, paused/muted/volume, channel name, live vs. VOD |
+
+The platform is detected per-sample from the page URL, so a single logger handles a session that navigates between sites.
+
+### How to enable it in a workflow
+
+QoE logging is exposed as two ordinary workflow **actions**, so you enable it by adding them to a workflow state (no flags or env vars required):
+
+| Action | Parameters | Description |
+|--------|------------|-------------|
+| `start_stats_logging` | `out_path` (default `netgent_video_stats.jsonl`), `interval` (seconds, default `2.0`) | Starts the background sampler. |
+| `stop_stats_logging` | — | Stops the sampler and flushes the log. (Also called automatically on browser shutdown.) |
+
+A typical pattern is to start logging once the player is present and keep the state alive for the session using the `"config": { "continuous": true }` state flag:
+
+```json
+{
+  "name": "Watching YouTube Video",
+  "description": "On a YouTube watch page - log QoE stats for the session",
+  "config": { "continuous": true },
+  "checks": [
+    { "type": "element", "params": { "by": "css selector", "selector": "#movie_player", "check_visibility": false, "timeout": 5 } }
+  ],
+  "actions": [
+    { "type": "start_stats_logging", "params": { "out_path": "youtube_stats.jsonl", "interval": 2.0 } },
+    { "type": "wait", "params": { "seconds": 5 } }
+  ],
+  "end_state": ""
+}
+```
+
+Because each sample is flushed to disk immediately (line-buffered append), the log survives even if the session is interrupted before `stop_stats_logging` runs.
+
+### Ready-to-run examples
+
+```bash
+# YouTube
+netgent -e examples/web_browsing/youtube/results/youtube_stats_result.json   # -> youtube_stats.jsonl
+
+# Twitch
+netgent -e examples/web_browsing/twitch-watch/results/twitch-stats_result.json   # -> twitch_stats.jsonl
+```
+
+Each line of the resulting JSONL file looks like:
+
+```json
+{"timestamp": 1781242765.92, "url": "https://www.youtube.com/watch?v=...", "stats": {"platform": "youtube", "resolution": "1920x1080", "bandwidth_kbps": "5120 Kbps", "buffer_health_seconds": "12.34 s", "dropped_video_frames": 0, "total_video_frames": 900, "title": "...", "author": "..."}}
+```
+
+> **Note:** Browsers block autoplay on fresh, gesture-less sessions, so a video may load paused (reporting `0x0` resolution and zeroed playback counters). To capture live playback metrics, make sure the workflow actually starts playback (e.g. a click on the player or a `playVideo()` call) before/while logging.
+
+The generated `*_stats.jsonl` logs are git-ignored.

--- a/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
+++ b/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "On Browser Home Page",
+    "description": "Start the Process",
+    "checks": [
+      {
+        "type": "url",
+        "params": {
+          "url": "chrome://new-tab-page/"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "navigate",
+        "params": {
+          "url": "https://www.twitch.tv/"
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Navigated to Twitch; the On Twitch Home Page state will pick a stream."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "On Twitch Home Page",
+    "description": "On Twitch Home Page - open a live stream",
+    "checks": [
+      {
+        "type": "text",
+        "params": {
+          "text": "Live on Twitch"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "click",
+        "params": {
+          "by": "css selector",
+          "selector": "div.ScAspectRatio-sc-18km980-1.jgpfbi.tw-aspect",
+          "x": 354.5859375,
+          "y": 1272.90625
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 8
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Opened a stream; the Watching Twitch Stream state will take over."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "Watching Twitch Stream",
+    "description": "On a Twitch stream page - start logging video stats and keep sampling for the session",
+    "config": {
+      "continuous": true
+    },
+    "checks": [
+      {
+        "type": "element",
+        "params": {
+          "by": "css selector",
+          "selector": "video"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "start_stats_logging",
+        "params": {
+          "out_path": "twitch_stats.jsonl",
+          "interval": 2.0
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 5
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  }
+]

--- a/examples/web_browsing/youtube/results/youtube_stats_result.json
+++ b/examples/web_browsing/youtube/results/youtube_stats_result.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "On Browser Home Page",
+    "description": "Start the Process",
+    "checks": [
+      {
+        "type": "url",
+        "params": {
+          "url": "chrome://new-tab-page/"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "navigate",
+        "params": {
+          "url": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 10
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Navigated to the watch page and waited for it to load; the Watching YouTube Video state will take over."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "Watching YouTube Video",
+    "description": "On a YouTube watch page - start logging Stats for Nerds and keep sampling for the session",
+    "config": {
+      "continuous": true
+    },
+    "checks": [
+      {
+        "type": "element",
+        "params": {
+          "by": "css selector",
+          "selector": "#movie_player",
+          "check_visibility": false,
+          "timeout": 5
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "start_stats_logging",
+        "params": {
+          "out_path": "youtube_stats.jsonl",
+          "interval": 2.0
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 5
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  }
+]

--- a/src/netgent/browser/controller/base.py
+++ b/src/netgent/browser/controller/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from seleniumbase import Driver
 import time
 from ..registry import action, trigger, ActionTriggerMeta
+from ..stats_logger import VideoStatsLogger
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -13,11 +14,29 @@ class BaseController(ABC, metaclass=ActionTriggerMeta):
     
     def __init__(self, driver: Driver):
         self.driver = driver
+        self.stats_logger = VideoStatsLogger(driver)
 
     @action()
     def navigate(self, url: str):
         """Navigate to a specified URL"""
         self.driver.get(url)
+
+    @action()
+    def start_stats_logging(self, out_path: str = "netgent_video_stats.jsonl", interval: float = 2.0):
+        """Start logging video 'Stats for Nerds' metrics (YouTube/Twitch) to a JSONL file in the background.
+
+        Args:
+            out_path: File to append JSONL stats samples to
+            interval: Seconds between samples
+        """
+        self.stats_logger.configure(out_path=out_path, interval=interval)
+        self.stats_logger.start()
+        return out_path
+
+    @action()
+    def stop_stats_logging(self):
+        """Stop the background video stats logger and flush the log file."""
+        self.stats_logger.stop()
 
     @action()
     def wait(self, seconds: float):
@@ -32,6 +51,8 @@ class BaseController(ABC, metaclass=ActionTriggerMeta):
     
     def quit(self):
         """Quit the browser (not an action - used for cleanup)"""
+        if self.stats_logger:
+            self.stats_logger.stop()
         if self.driver:
             self.driver.quit()
 

--- a/src/netgent/browser/stats_logger.py
+++ b/src/netgent/browser/stats_logger.py
@@ -1,0 +1,213 @@
+"""
+Background "Stats for Nerds" logger for video-streaming sessions.
+
+Supported platforms:
+  * YouTube - reads the player object directly via `movie_player.getStatsForNerds()`
+    (the same data behind the right-click "Stats for Nerds" overlay), merged with
+    the raw <video> element.
+  * Twitch - has no public "Stats for Nerds" API, so we read the standard
+    HTMLVideoElement API (resolution, dropped/total frames, buffer-ahead,
+    playback state) plus the channel name from the URL.
+
+A daemon thread samples on a fixed interval and appends one JSON object per sample
+to a JSONL file, so the log survives even if the session crashes before `stop()`
+is called.
+
+Note on thread-safety: Selenium drivers are not strictly thread-safe. We sample
+from a background thread while the main state-machine loop also touches the
+driver, so every sample is wrapped in try/except - a transient collision skips a
+single sample rather than crashing the run. Sampling every couple of seconds
+against a loop that mostly sleeps makes collisions rare in practice.
+"""
+
+import json
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+
+# Runs in the page. Detects the platform by hostname and returns a normalized
+# stats object. Returns {"platform": "unknown", "error": ...} if no player/video
+# is present. Field names mirror each platform's native terminology where useful.
+_STATS_JS = r"""
+const host = location.hostname || '';
+
+function youtubeStats() {
+    const player = document.getElementById('movie_player')
+        || document.querySelector('.html5-video-player');
+    const video = document.querySelector('video');
+    if (!player && !video) { return {platform: 'youtube', error: 'no_player'}; }
+
+    const out = {platform: 'youtube'};
+    try {
+        if (player && typeof player.getStatsForNerds === 'function') {
+            Object.assign(out, player.getStatsForNerds());
+        }
+    } catch (e) { out.stats_for_nerds_error = String(e); }
+
+    try {
+        if (player && typeof player.getVideoData === 'function') {
+            const d = player.getVideoData();
+            out.video_id = d && d.video_id;
+            out.title = d && d.title;
+            out.author = d && d.author;
+            out.is_live = d && d.isLive;
+        }
+        if (player && typeof player.getCurrentTime === 'function') {
+            out.current_time_secs = player.getCurrentTime();
+        }
+        if (player && typeof player.getDuration === 'function') {
+            out.duration_secs = player.getDuration();
+        }
+        if (player && typeof player.getVideoLoadedFraction === 'function') {
+            out.loaded_fraction = player.getVideoLoadedFraction();
+        }
+        if (player && typeof player.getPlayerState === 'function') {
+            out.player_state = player.getPlayerState();
+        }
+    } catch (e) { out.player_data_error = String(e); }
+
+    addVideoElementStats(out, video);
+    return out;
+}
+
+function twitchStats() {
+    const video = document.querySelector('video');
+    if (!video) { return {platform: 'twitch', error: 'no_video'}; }
+
+    const out = {platform: 'twitch'};
+    try {
+        // Channel name from the first non-empty path segment (e.g. /channelname).
+        const seg = location.pathname.split('/').filter(Boolean);
+        out.channel = seg.length ? seg[0] : null;
+        out.is_live = true; // Twitch watch pages are live unless it's a VOD (/videos/).
+        if (location.pathname.startsWith('/videos/')) {
+            out.is_live = false;
+            out.video_id = seg.length > 1 ? seg[1] : null;
+        }
+    } catch (e) { out.page_data_error = String(e); }
+
+    addVideoElementStats(out, video);
+    return out;
+}
+
+function addVideoElementStats(out, video) {
+    try {
+        if (!video) { return; }
+        out.video_width = video.videoWidth;
+        out.video_height = video.videoHeight;
+        out.resolution = video.videoWidth + 'x' + video.videoHeight;
+        out.playback_rate = video.playbackRate;
+        out.paused = video.paused;
+        out.muted = video.muted;
+        out.volume = video.volume;
+        out.current_time_secs = out.current_time_secs != null
+            ? out.current_time_secs : video.currentTime;
+        // Buffer-ahead: how many seconds are buffered past the current position.
+        if (video.buffered && video.buffered.length) {
+            const end = video.buffered.end(video.buffered.length - 1);
+            out.buffer_ahead_secs = Math.max(0, end - video.currentTime);
+        }
+        if (typeof video.getVideoPlaybackQuality === 'function') {
+            const q = video.getVideoPlaybackQuality();
+            out.dropped_video_frames = q.droppedVideoFrames;
+            out.total_video_frames = q.totalVideoFrames;
+            if ('corruptedVideoFrames' in q) {
+                out.corrupted_video_frames = q.corruptedVideoFrames;
+            }
+        }
+    } catch (e) { out.video_element_error = String(e); }
+}
+
+if (host.indexOf('youtube.com') !== -1 || host.indexOf('youtu.be') !== -1) {
+    return youtubeStats();
+}
+if (host.indexOf('twitch.tv') !== -1) {
+    return twitchStats();
+}
+// Fallback: try whatever <video> is on the page.
+const video = document.querySelector('video');
+if (!video) { return {platform: 'unknown', error: 'no_video'}; }
+const out = {platform: 'unknown'};
+addVideoElementStats(out, video);
+return out;
+"""
+
+
+class VideoStatsLogger:
+    """Samples video-player stats on a background thread into a JSONL file.
+
+    Site-aware: works on YouTube ("Stats for Nerds") and Twitch (HTMLVideoElement
+    metrics). The platform is detected per-sample from the page, so a single
+    logger handles a session that navigates between sites.
+    """
+
+    def __init__(self, driver, out_path: str = "netgent_video_stats.jsonl",
+                 interval: float = 2.0):
+        self.driver = driver
+        self.out_path = out_path
+        self.interval = interval
+        self._thread = None
+        self._stop_event = threading.Event()
+
+    def configure(self, out_path: str = None, interval: float = None):
+        """Update output path / interval before starting."""
+        if out_path is not None:
+            self.out_path = out_path
+        if interval is not None:
+            self.interval = interval
+
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def sample(self) -> dict:
+        """Capture a single stats snapshot (stamped with time and URL)."""
+        sample = {"timestamp": time.time()}
+        try:
+            sample["url"] = self.driver.current_url
+        except Exception:
+            sample["url"] = None
+        try:
+            stats = self.driver.execute_script(_STATS_JS)
+            sample["stats"] = stats
+        except Exception as e:
+            sample["stats"] = None
+            sample["sample_error"] = str(e)
+        return sample
+
+    def _run(self):
+        # Line-buffered append so each sample is flushed to disk immediately.
+        with open(self.out_path, "a", buffering=1) as f:
+            while not self._stop_event.is_set():
+                sample = self.sample()
+                try:
+                    f.write(json.dumps(sample) + "\n")
+                except Exception as e:
+                    logger.warning(f"Failed to write stats sample: {e}")
+                # Wait the interval, but wake immediately on stop().
+                self._stop_event.wait(self.interval)
+
+    def start(self):
+        if self.is_running():
+            logger.info("Stats logger already running; ignoring start()")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True,
+                                        name="video-stats-logger")
+        self._thread.start()
+        logger.info(f"Video stats logging started -> {self.out_path} "
+                    f"(every {self.interval}s)")
+
+    def stop(self):
+        if not self.is_running():
+            return
+        self._stop_event.set()
+        self._thread.join(timeout=self.interval + 5)
+        logger.info(f"Video stats logging stopped -> {self.out_path}")
+        self._thread = None
+
+
+# Backwards-compatible alias (the logger now covers Twitch as well as YouTube).
+YouTubeStatsLogger = VideoStatsLogger


### PR DESCRIPTION
Issue #19 
▎ What
**▎**
▎ Adds a background Quality-of-Experience (QoE) logger that records video-player "Stats for Nerds" metrics throughout a streaming session and writes one JSON object per sample to a JSONL file. This lets us correlate the network traffic NetGent generates with the player's perceived playback quality.
▎
▎ How it works
▎
▎ - New VideoStatsLogger (src/netgent/browser/stats_logger.py) samples on a daemon thread at a configurable interval and line-buffers each sample to disk, so logs survive an interrupted session.
▎ - Metrics are read directly from the player via JS rather than scraping the fragile right-click overlay. Platform is detected per-sample by hostname, so one logger handles a session that hops between sites:
▎   - YouTube → movie_player.getStatsForNerds() + <video> (resolution, codecs, bandwidth, buffer health, dropped/total frames, network activity, live latency, video id/title/author)
▎   - Twitch → HTMLVideoElement API (resolution, dropped/total frames, buffer-ahead, playback rate, channel, live vs. VOD)
▎ - Exposed as two ordinary workflow actions — start_stats_logging(out_path, interval) and stop_stats_logging() — auto-registered through the existing action metaclass. No new flags or env vars. The logger is also stopped on browser shutdown via BaseController.quit().
▎
▎ Usage
▎
▎ Add the actions to a workflow state (typically a "config": { "continuous": true } "watching" state). Two runnable examples are included:
▎ netgent -e examples/web_browsing/youtube/results/youtube_stats_result.json   # -> youtube_stats.jsonl
▎ netgent -e examples/web_browsing/twitch-watch/results/twitch-stats_result.json # -> twitch_stats.jsonl
▎ Full docs in the new README "QoE Logging (Stats for Nerds)" section.
▎
▎ Testing
▎
▎ Ran the YouTube example end-to-end: browser launched, navigated to the watch page, entered the continuous watch state, and the logger captured timestamped samples every 2s to youtube_stats.jsonl with rich getStatsForNerds() data (bandwidth, codecs, title/author, frame counts). No errors.
▎
▎ Notes
▎
▎ - Browsers block autoplay on fresh sessions, so a video can load paused (reporting 0x0/zeroed counters). To capture live playback metrics, the workflow should actively start playback before/while logging. Documented in the README.
▎ - Generated *_stats.jsonl logs are git-ignored.
▎ - No changes needed to the registry, executor, or web-agent — the action metaclass wires the new actions in automatically.