### PR TITLE
Add concurrent multi-application workflow execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,8 @@ downloaded_files/
 google_creds.json
 
 google_key.json
+
+# QoE / Stats-for-Nerds logs (generated at runtime)
+*_stats.jsonl
+netgent_video_stats.jsonl
+run.log

--- a/README.md
+++ b/README.md
@@ -212,3 +212,58 @@ Each line of the resulting JSONL file looks like:
 > **Note:** Browsers block autoplay on fresh, gesture-less sessions, so a video may load paused (reporting `0x0` resolution and zeroed playback counters). To capture live playback metrics, make sure the workflow actually starts playback (e.g. a click on the player or a `playVideo()` call) before/while logging.
 
 The generated `*_stats.jsonl` logs are git-ignored.
+
+## Running Multiple Applications Concurrently
+
+NetGent can run **several application workflows at the same time** in a single invocation — for example, watching YouTube while also streaming Twitch and running a `wget` download. This is separate from generating workflows with AI; it is purely about *executing* one or more pre-built workflows in parallel.
+
+### How it works
+
+You pass **one or more workflow files**, and each is classified by its extension:
+
+| Extension | Type | What runs |
+|-----------|------|-----------|
+| `*.json` | NetGent executable workflow | A full browser session. Each one gets its **own virtual display, its own Chrome profile, and (with `-s`) its own noVNC port**, so their mouse/keyboard inputs never collide. |
+| `*.sh` | Bash workflow | An arbitrary shell command (e.g. `wget`, `ping`, `curl`). No browser/display is used. |
+
+Key behaviors:
+
+- **Isolation:** every browser workflow runs on its own display (`:99`, `:100`, …) with its own Chrome profile, so concurrent workflows don't interfere with each other. A failure in one workflow does not stop the others.
+- **Live viewing:** with `-s`, each browser workflow is assigned its own noVNC port, sequentially from `8080` (1st browser → `:8080`, 2nd → `:8081`, …). Open one browser tab per workflow to watch them live, exactly like the single-workflow view. Map each port you want to see.
+- **Output:** per-workflow results and logs are written under `out/<workflow-name>/` (e.g. `out/youtube/youtube_result.json`, `out/youtube/youtube.log`). Bash workflows also run in their own `out/<name>/` directory, so relative output files never clobber each other.
+- **Completion:** the run finishes once **all** workflows have completed.
+- Single-workflow usage (`-e` / `-g`) is unchanged and fully backward compatible.
+
+Two ready-to-run bash workflow examples are provided in [`examples/bash_workflows/`](examples/bash_workflows/): `wget-download.sh` and `ping.sh`.
+
+> **Resource note:** each browser workflow starts its own Chrome + virtual display, so memory/CPU usage grows with the number of concurrent browser workflows.
+
+### Docker
+
+Pass the workflow files as the container's arguments and map one host port per browser workflow you want to watch:
+
+```bash
+docker run --platform=linux/amd64 --rm -d \
+  -p 8080:8080 -p 8081:8081 \
+  -v "$PWD/examples/web_browsing/youtube/results/youtube_stats_result.json:/youtube.json:ro" \
+  -v "$PWD/examples/web_browsing/twitch-watch/results/twitch-stats_result.json:/twitch.json:ro" \
+  -v "$PWD/examples/bash_workflows/wget-download.sh:/wget.sh:ro" \
+  -v "$PWD/out:/out" \
+  netgent \
+  /youtube.json /twitch.json /wget.sh -s
+```
+
+- `youtube` (1st browser workflow) → watch at http://localhost:8080
+- `twitch` (2nd browser workflow) → watch at http://localhost:8081
+- `wget` (bash workflow) → no screen; output and logs in `out/wget/`
+- Results/logs for each are written under the mounted `out/` directory.
+
+### CLI
+
+Inside the container the same orchestrator is available on `PATH` as `start-netgent`, accepting the same arguments. This is useful when you already have a running container:
+
+```bash
+start-netgent /youtube.json /twitch.json /wget.sh -s
+```
+
+> The multi-workflow orchestrator manages the virtual displays (Xvfb), VNC, and noVNC servers, which are only present inside the provided Docker image. Run it via the container (as the entrypoint above) or from a shell inside the container, rather than directly on a host without an X server.

--- a/README.md
+++ b/README.md
@@ -148,3 +148,67 @@ results = agent.run(state_prompts=[], state_repository=your_saved_repo)
 See the example scripts and CLI source for more patterns, and customize credentials or cache directory as needed.
 
 For API key configuration details, refer to [API_KEYS.md](API_KEYS.md).
+
+## QoE Logging (Stats for Nerds)
+
+NetGent can record video Quality-of-Experience (QoE) metrics throughout a streaming session, the same data that YouTube exposes via its "Stats for Nerds" overlay. This is useful for correlating the network traffic NetGent generates with the player's perceived playback quality.
+
+Instead of scraping the fragile right-click overlay, the logger reads the metrics directly from the player via JavaScript and samples them on a background thread, writing one JSON object per sample to a JSONL file.
+
+### Supported platforms
+
+| Platform | Source | Captured metrics (when playing) |
+|----------|--------|---------------------------------|
+| **YouTube** | `movie_player.getStatsForNerds()` + `<video>` | resolution, codecs, bandwidth, buffer health, dropped/total frames, network activity, live latency, video id/title/author |
+| **Twitch** | `HTMLVideoElement` API | resolution, dropped/total frames, buffer-ahead seconds, playback rate, paused/muted/volume, channel name, live vs. VOD |
+
+The platform is detected per-sample from the page URL, so a single logger handles a session that navigates between sites.
+
+### How to enable it in a workflow
+
+QoE logging is exposed as two ordinary workflow **actions**, so you enable it by adding them to a workflow state (no flags or env vars required):
+
+| Action | Parameters | Description |
+|--------|------------|-------------|
+| `start_stats_logging` | `out_path` (default `netgent_video_stats.jsonl`), `interval` (seconds, default `2.0`) | Starts the background sampler. |
+| `stop_stats_logging` | — | Stops the sampler and flushes the log. (Also called automatically on browser shutdown.) |
+
+A typical pattern is to start logging once the player is present and keep the state alive for the session using the `"config": { "continuous": true }` state flag:
+
+```json
+{
+  "name": "Watching YouTube Video",
+  "description": "On a YouTube watch page - log QoE stats for the session",
+  "config": { "continuous": true },
+  "checks": [
+    { "type": "element", "params": { "by": "css selector", "selector": "#movie_player", "check_visibility": false, "timeout": 5 } }
+  ],
+  "actions": [
+    { "type": "start_stats_logging", "params": { "out_path": "youtube_stats.jsonl", "interval": 2.0 } },
+    { "type": "wait", "params": { "seconds": 5 } }
+  ],
+  "end_state": ""
+}
+```
+
+Because each sample is flushed to disk immediately (line-buffered append), the log survives even if the session is interrupted before `stop_stats_logging` runs.
+
+### Ready-to-run examples
+
+```bash
+# YouTube
+netgent -e examples/web_browsing/youtube/results/youtube_stats_result.json   # -> youtube_stats.jsonl
+
+# Twitch
+netgent -e examples/web_browsing/twitch-watch/results/twitch-stats_result.json   # -> twitch_stats.jsonl
+```
+
+Each line of the resulting JSONL file looks like:
+
+```json
+{"timestamp": 1781242765.92, "url": "https://www.youtube.com/watch?v=...", "stats": {"platform": "youtube", "resolution": "1920x1080", "bandwidth_kbps": "5120 Kbps", "buffer_health_seconds": "12.34 s", "dropped_video_frames": 0, "total_video_frames": 900, "title": "...", "author": "..."}}
+```
+
+> **Note:** Browsers block autoplay on fresh, gesture-less sessions, so a video may load paused (reporting `0x0` resolution and zeroed playback counters). To capture live playback metrics, make sure the workflow actually starts playback (e.g. a click on the player or a `playVideo()` call) before/while logging.
+
+The generated `*_stats.jsonl` logs are git-ignored.

--- a/examples/bash_workflows/ping.sh
+++ b/examples/bash_workflows/ping.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# A sample non-browser NetGent workflow: ping a host to generate steady,
+# low-rate background traffic. Runs concurrently alongside browser workflows.
+set -euo pipefail
+
+HOST="${PING_HOST:-8.8.8.8}"
+COUNT="${PING_COUNT:-20}"
+
+echo "[ping] pinging $HOST x$COUNT"
+ping -c "$COUNT" "$HOST"
+echo "[ping] done"

--- a/examples/bash_workflows/wget-download.sh
+++ b/examples/bash_workflows/wget-download.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# A sample non-browser NetGent workflow: download a file with wget to generate
+# bulk-transfer network traffic. Runs concurrently alongside browser workflows.
+#
+# Output is written to the current working directory, which the orchestrator
+# sets to out/<workflow-name>/ so parallel workflows never clobber each other.
+set -euo pipefail
+
+URL="${WGET_URL:-https://speed.hetzner.de/100MB.bin}"
+
+echo "[wget] downloading: $URL"
+wget --no-verbose --output-document=download.bin "$URL"
+echo "[wget] done: $(ls -lh download.bin | awk '{print $5}')"

--- a/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
+++ b/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
@@ -77,6 +77,15 @@
           "by": "css selector",
           "selector": "video"
         }
+      },
+      {
+        "type": "element",
+        "params": {
+          "by": "css selector",
+          "selector": ".channel-root, [data-test-selector=\"chat-scrollable-area__message-container\"], [data-a-target=\"chat-input\"], [data-a-target=\"chat-scrollable-area__message-container\"]",
+          "check_visibility": false,
+          "timeout": 5
+        }
       }
     ],
     "actions": [

--- a/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
+++ b/examples/web_browsing/twitch-watch/results/twitch-stats_result.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "On Browser Home Page",
+    "description": "Start the Process",
+    "checks": [
+      {
+        "type": "url",
+        "params": {
+          "url": "chrome://new-tab-page/"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "navigate",
+        "params": {
+          "url": "https://www.twitch.tv/"
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Navigated to Twitch; the On Twitch Home Page state will pick a stream."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "On Twitch Home Page",
+    "description": "On Twitch Home Page - open a live stream",
+    "checks": [
+      {
+        "type": "text",
+        "params": {
+          "text": "Live on Twitch"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "click",
+        "params": {
+          "by": "css selector",
+          "selector": "div.ScAspectRatio-sc-18km980-1.jgpfbi.tw-aspect",
+          "x": 354.5859375,
+          "y": 1272.90625
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 8
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Opened a stream; the Watching Twitch Stream state will take over."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "Watching Twitch Stream",
+    "description": "On a Twitch stream page - start logging video stats and keep sampling for the session",
+    "config": {
+      "continuous": true
+    },
+    "checks": [
+      {
+        "type": "element",
+        "params": {
+          "by": "css selector",
+          "selector": "video"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "start_stats_logging",
+        "params": {
+          "out_path": "twitch_stats.jsonl",
+          "interval": 2.0
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 5
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  }
+]

--- a/examples/web_browsing/youtube/results/youtube_stats_result.json
+++ b/examples/web_browsing/youtube/results/youtube_stats_result.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "On Browser Home Page",
+    "description": "Start the Process",
+    "checks": [
+      {
+        "type": "url",
+        "params": {
+          "url": "chrome://new-tab-page/"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "navigate",
+        "params": {
+          "url": "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 10
+        }
+      },
+      {
+        "type": "terminate",
+        "params": {
+          "reason": "Navigated to the watch page and waited for it to load; the Watching YouTube Video state will take over."
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  },
+  {
+    "name": "Watching YouTube Video",
+    "description": "On a YouTube watch page - start logging Stats for Nerds and keep sampling for the session",
+    "config": {
+      "continuous": true
+    },
+    "checks": [
+      {
+        "type": "element",
+        "params": {
+          "by": "css selector",
+          "selector": "#movie_player",
+          "check_visibility": false,
+          "timeout": 5
+        }
+      }
+    ],
+    "actions": [
+      {
+        "type": "start_stats_logging",
+        "params": {
+          "out_path": "youtube_stats.jsonl",
+          "interval": 2.0
+        }
+      },
+      {
+        "type": "wait",
+        "params": {
+          "seconds": 5
+        }
+      }
+    ],
+    "end_state": "",
+    "executed": []
+  }
+]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,98 +1,189 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Only set DISPLAY if virtual display is enabled later
-export RESOLUTION="${RESOLUTION:-1920x1080x24}"
-export NOVNC_PORT="${NOVNC_PORT:-8080}"
-export VNC_PORT="${VNC_PORT:-5900}"
-export VNC_LISTEN_HOST="${VNC_LISTEN_HOST:-localhost}"
+# ---------------------------------------------------------------------------
+# NetGent container entrypoint.
+#
+# Two modes, auto-detected from the arguments:
+#
+#   1. Legacy single-workflow mode (unchanged): invoked with the netgent CLI
+#      flags -e/--execute or -g/--generate. One browser on display :99, one
+#      optional noVNC view on $NOVNC_PORT. Delegates to cli.py exactly as before.
+#
+#   2. Multi-workflow mode: invoked with one or more positional workflow files.
+#      Each file is run concurrently:
+#        - *.json  -> a NetGent executable workflow (its own browser, its own
+#                     Xvfb display, its own Chrome profile, and -- with -s --
+#                     its own noVNC port so the cursors never collide).
+#        - *.sh    -> an arbitrary bash workflow (wget, ping, ...). No display.
+#      Example:  start-netgent youtube.json netflix.json ping.sh -s
+# ---------------------------------------------------------------------------
 
+export RESOLUTION="${RESOLUTION:-1920x1080x24}"
+export VNC_LISTEN_HOST="${VNC_LISTEN_HOST:-localhost}"
+BASE_NOVNC_PORT="${NOVNC_PORT:-8080}"
+BASE_VNC_PORT="${VNC_PORT:-5900}"
+BASE_DISPLAY_NUM="${BASE_DISPLAY_NUM:-99}"
+
+# Where per-workflow results and logs go. Prefer a mounted /out, else ./out.
+OUT_DIR="${OUT_DIR:-/out}"
+if [ ! -d "$OUT_DIR" ]; then
+  OUT_DIR="$(pwd)/out"
+fi
+mkdir -p "$OUT_DIR"
+
+# --- Argument inspection ---------------------------------------------------
 USE_VDISPLAY=0
+LEGACY=0
+WORKFLOWS=()
 for arg in "$@"; do
   case "$arg" in
     -s|--screen)
       USE_VDISPLAY=1
       ;;
+    -e|--execute|-g|--generate)
+      LEGACY=1
+      ;;
+    *)
+      WORKFLOWS+=("$arg")
+      ;;
   esac
 done
 
-if [ "$USE_VDISPLAY" -eq 1 ]; then
-  echo "Starting VNC/noVNC setup..."
-  export DISPLAY="${DISPLAY:-:99}"
-  Xvfb "$DISPLAY" -screen 0 "$RESOLUTION" &
+# --- Bring up an X display (and, optionally, a noVNC view) for it -----------
+# start_display <display_num> <vnc_port> <novnc_port> <use_vnc>
+start_display() {
+  local dnum="$1" vncport="$2" novncport="$3" usevnc="$4"
+  local disp=":${dnum}"
+
+  Xvfb "$disp" -screen 0 "$RESOLUTION" &
   sleep 2
-
-  fluxbox 2>/dev/null &
+  # Lightweight WM for proper window focus/placement (needed by pyautogui).
+  DISPLAY="$disp" fluxbox 2>/dev/null &
   sleep 1
 
-  # Keep raw VNC local; noVNC proxies to it
-  # Use -viewonly flag to make VNC read-only (view-only mode)
-  echo "Starting x11vnc on port $VNC_PORT (view-only mode)..."
-  if [ -n "${VNC_PASSWORD:-}" ]; then
-    x11vnc -display "$DISPLAY" -bg -forever -quiet \
-            -listen "$VNC_LISTEN_HOST" -xkb -nodpms -viewonly \
-            -rfbport "$VNC_PORT" -passwd "$VNC_PASSWORD" &
-  else
-    x11vnc -display "$DISPLAY" -bg -forever -nopw -quiet \
-            -listen "$VNC_LISTEN_HOST" -xkb -nodpms -viewonly \
-            -rfbport "$VNC_PORT" &
-  fi
-  sleep 1
-
-  # Start websockify (noVNC) - bind to 0.0.0.0 to allow access from outside container
-  echo "Starting websockify on port $NOVNC_PORT..."
-  cd /opt/noVNC/utils/websockify || { echo "ERROR: Cannot find /opt/noVNC/utils/websockify"; exit 1; }
-  
-  # Try different methods to start websockify
-  WEBSOCKIFY_PID=""
-  if [ -f "websockify.py" ]; then
-    echo "Using websockify.py..."
-    python3 websockify.py --web /opt/noVNC 0.0.0.0:$NOVNC_PORT localhost:$VNC_PORT > /tmp/websockify.log 2>&1 &
-    WEBSOCKIFY_PID=$!
-  elif python3 -c "import websockify" 2>/dev/null; then
-    echo "Using python3 -m websockify..."
-    python3 -m websockify --web /opt/noVNC 0.0.0.0:$NOVNC_PORT localhost:$VNC_PORT > /tmp/websockify.log 2>&1 &
-    WEBSOCKIFY_PID=$!
-  else
-    echo "ERROR: websockify not found. Trying alternative..."
-    python3 -m websockify --web /opt/noVNC $NOVNC_PORT localhost:$VNC_PORT > /tmp/websockify.log 2>&1 &
-    WEBSOCKIFY_PID=$!
-  fi
-  
-  sleep 3
-  
-  # Verify websockify is running
-  if [ -n "$WEBSOCKIFY_PID" ] && ps -p $WEBSOCKIFY_PID > /dev/null 2>&1; then
-    echo "✓ websockify is running (PID: $WEBSOCKIFY_PID)"
-  else
-    echo "⚠ WARNING: websockify may not have started correctly"
-    echo "Check logs: cat /tmp/websockify.log"
-    if [ -f /tmp/websockify.log ]; then
-      tail -20 /tmp/websockify.log
+  if [ "$usevnc" -eq 1 ]; then
+    echo "Starting x11vnc for $disp on port $vncport (view-only)..."
+    if [ -n "${VNC_PASSWORD:-}" ]; then
+      x11vnc -display "$disp" -bg -forever -quiet \
+             -listen "$VNC_LISTEN_HOST" -xkb -nodpms -viewonly \
+             -rfbport "$vncport" -passwd "$VNC_PASSWORD"
+    else
+      x11vnc -display "$disp" -bg -forever -nopw -quiet \
+             -listen "$VNC_LISTEN_HOST" -xkb -nodpms -viewonly \
+             -rfbport "$vncport"
     fi
-  fi
-  
-  # Check if port is listening
-  if netstat -tuln 2>/dev/null | grep -q ":$NOVNC_PORT " || ss -tuln 2>/dev/null | grep -q ":$NOVNC_PORT "; then
-    echo "✓ Port $NOVNC_PORT is listening"
-  else
-    echo "⚠ WARNING: Port $NOVNC_PORT may not be listening. Checking processes..."
-    ps aux | grep -E 'websockify|x11vnc' | grep -v grep || echo "No VNC processes found"
-  fi
-  
-  echo "VNC/noVNC should be accessible at http://localhost:$NOVNC_PORT"
-else
-  # Start a bare X server so DISPLAY is usable, but skip VNC/noVNC
-  export DISPLAY="${DISPLAY:-:99}"
-  Xvfb "$DISPLAY" -screen 0 "$RESOLUTION" &
-  sleep 2
-  # Optional lightweight WM for proper focus handling; ignore failures
-  fluxbox 2>/dev/null &
-  sleep 1
-fi
 
+    echo "Starting websockify (noVNC) for $disp on port $novncport..."
+    python3 -m websockify --web /opt/noVNC \
+            "0.0.0.0:${novncport}" "localhost:${vncport}" \
+            > "/tmp/websockify_${novncport}.log" 2>&1 &
+    sleep 1
+    echo "  -> view at http://localhost:${novncport}"
+  fi
+}
+
+# Always run sshd (kept from the original entrypoint).
 mkdir -p /run/sshd
 /usr/sbin/sshd
 
-# Finally, launch the Python application:
-exec python3 /home/agent/app/src/netgent/cli.py "$@"
+# ===========================================================================
+# Legacy single-workflow mode: preserve the exact previous behavior.
+# ===========================================================================
+if [ "$LEGACY" -eq 1 ]; then
+  export DISPLAY=":${BASE_DISPLAY_NUM}"
+  if [ "$USE_VDISPLAY" -eq 1 ]; then
+    echo "Starting VNC/noVNC setup..."
+  fi
+  start_display "$BASE_DISPLAY_NUM" "$BASE_VNC_PORT" "$BASE_NOVNC_PORT" "$USE_VDISPLAY"
+  exec python3 /home/agent/app/src/netgent/cli.py "$@"
+fi
+
+# ===========================================================================
+# Multi-workflow mode.
+# ===========================================================================
+if [ "${#WORKFLOWS[@]}" -eq 0 ]; then
+  echo "Error: no workflows provided."
+  echo "Usage: start-netgent [-s] <workflow1> [<workflow2> ...]"
+  echo "  *.json -> NetGent executable workflow (browser)"
+  echo "  *.sh   -> bash workflow (wget, ping, ...)"
+  exit 1
+fi
+
+echo "=== NetGent multi-workflow run: ${#WORKFLOWS[@]} workflow(s) ==="
+[ "$USE_VDISPLAY" -eq 1 ] && echo "Live viewing enabled (one noVNC port per browser workflow)."
+
+declare -a PIDS=()
+declare -a NAMES=()
+dnum="$BASE_DISPLAY_NUM"
+vncport="$BASE_VNC_PORT"
+novncport="$BASE_NOVNC_PORT"
+
+for wf in "${WORKFLOWS[@]}"; do
+  base="$(basename "$wf")"
+  name="${base%.*}"
+  # Resolve to an absolute path so a per-workflow cwd doesn't break it.
+  wfabs="$(readlink -f "$wf" 2>/dev/null || echo "$wf")"
+  wdir="$OUT_DIR/$name"
+  mkdir -p "$wdir"
+
+  if [ ! -f "$wfabs" ]; then
+    echo "[$name] WARNING: file not found ($wf) - skipping"
+    continue
+  fi
+
+  case "$wf" in
+    *.json)
+      start_display "$dnum" "$vncport" "$novncport" "$USE_VDISPLAY"
+      if [ "$USE_VDISPLAY" -eq 1 ]; then
+        echo "[$name] browser workflow on DISPLAY :${dnum} -> watch at http://localhost:${novncport}"
+      else
+        echo "[$name] browser workflow on DISPLAY :${dnum} (no screen)"
+      fi
+      (
+        cd "$wdir"
+        DISPLAY=":${dnum}" python3 /home/agent/app/src/netgent/cli.py \
+          -e "$wfabs" \
+          --user-data-dir "/tmp/netgent-profiles/${name}" \
+          -o "$wdir/${name}_result.json" \
+          > "$wdir/${name}.log" 2>&1
+      ) &
+      PIDS+=($!)
+      NAMES+=("$name")
+      dnum=$((dnum + 1))
+      vncport=$((vncport + 1))
+      novncport=$((novncport + 1))
+      ;;
+    *.sh)
+      echo "[$name] bash workflow -> logging to $wdir/${name}.log"
+      (
+        cd "$wdir"
+        bash "$wfabs" > "$wdir/${name}.log" 2>&1
+      ) &
+      PIDS+=($!)
+      NAMES+=("$name")
+      ;;
+    *)
+      echo "[$name] WARNING: unsupported type (expected .json or .sh) - skipping"
+      ;;
+  esac
+done
+
+echo "=== ${#PIDS[@]} workflow(s) launched. Waiting for completion... ==="
+
+overall_status=0
+for i in "${!PIDS[@]}"; do
+  pid="${PIDS[$i]}"
+  wf_name="${NAMES[$i]}"
+  if wait "$pid"; then
+    echo "[$wf_name] completed successfully."
+  else
+    code=$?
+    echo "[$wf_name] FAILED (exit $code)."
+    overall_status=1
+  fi
+done
+
+echo "=== All workflows finished (overall status: $overall_status) ==="
+echo "Results and logs are in: $OUT_DIR/<workflow-name>/"
+exit "$overall_status"

--- a/src/netgent/browser/controller/base.py
+++ b/src/netgent/browser/controller/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from seleniumbase import Driver
 import time
 from ..registry import action, trigger, ActionTriggerMeta
+from ..stats_logger import VideoStatsLogger
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -13,11 +14,29 @@ class BaseController(ABC, metaclass=ActionTriggerMeta):
     
     def __init__(self, driver: Driver):
         self.driver = driver
+        self.stats_logger = VideoStatsLogger(driver)
 
     @action()
     def navigate(self, url: str):
         """Navigate to a specified URL"""
         self.driver.get(url)
+
+    @action()
+    def start_stats_logging(self, out_path: str = "netgent_video_stats.jsonl", interval: float = 2.0):
+        """Start logging video 'Stats for Nerds' metrics (YouTube/Twitch) to a JSONL file in the background.
+
+        Args:
+            out_path: File to append JSONL stats samples to
+            interval: Seconds between samples
+        """
+        self.stats_logger.configure(out_path=out_path, interval=interval)
+        self.stats_logger.start()
+        return out_path
+
+    @action()
+    def stop_stats_logging(self):
+        """Stop the background video stats logger and flush the log file."""
+        self.stats_logger.stop()
 
     @action()
     def wait(self, seconds: float):
@@ -32,6 +51,8 @@ class BaseController(ABC, metaclass=ActionTriggerMeta):
     
     def quit(self):
         """Quit the browser (not an action - used for cleanup)"""
+        if self.stats_logger:
+            self.stats_logger.stop()
         if self.driver:
             self.driver.quit()
 

--- a/src/netgent/browser/stats_logger.py
+++ b/src/netgent/browser/stats_logger.py
@@ -1,0 +1,213 @@
+"""
+Background "Stats for Nerds" logger for video-streaming sessions.
+
+Supported platforms:
+  * YouTube - reads the player object directly via `movie_player.getStatsForNerds()`
+    (the same data behind the right-click "Stats for Nerds" overlay), merged with
+    the raw <video> element.
+  * Twitch - has no public "Stats for Nerds" API, so we read the standard
+    HTMLVideoElement API (resolution, dropped/total frames, buffer-ahead,
+    playback state) plus the channel name from the URL.
+
+A daemon thread samples on a fixed interval and appends one JSON object per sample
+to a JSONL file, so the log survives even if the session crashes before `stop()`
+is called.
+
+Note on thread-safety: Selenium drivers are not strictly thread-safe. We sample
+from a background thread while the main state-machine loop also touches the
+driver, so every sample is wrapped in try/except - a transient collision skips a
+single sample rather than crashing the run. Sampling every couple of seconds
+against a loop that mostly sleeps makes collisions rare in practice.
+"""
+
+import json
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+
+# Runs in the page. Detects the platform by hostname and returns a normalized
+# stats object. Returns {"platform": "unknown", "error": ...} if no player/video
+# is present. Field names mirror each platform's native terminology where useful.
+_STATS_JS = r"""
+const host = location.hostname || '';
+
+function youtubeStats() {
+    const player = document.getElementById('movie_player')
+        || document.querySelector('.html5-video-player');
+    const video = document.querySelector('video');
+    if (!player && !video) { return {platform: 'youtube', error: 'no_player'}; }
+
+    const out = {platform: 'youtube'};
+    try {
+        if (player && typeof player.getStatsForNerds === 'function') {
+            Object.assign(out, player.getStatsForNerds());
+        }
+    } catch (e) { out.stats_for_nerds_error = String(e); }
+
+    try {
+        if (player && typeof player.getVideoData === 'function') {
+            const d = player.getVideoData();
+            out.video_id = d && d.video_id;
+            out.title = d && d.title;
+            out.author = d && d.author;
+            out.is_live = d && d.isLive;
+        }
+        if (player && typeof player.getCurrentTime === 'function') {
+            out.current_time_secs = player.getCurrentTime();
+        }
+        if (player && typeof player.getDuration === 'function') {
+            out.duration_secs = player.getDuration();
+        }
+        if (player && typeof player.getVideoLoadedFraction === 'function') {
+            out.loaded_fraction = player.getVideoLoadedFraction();
+        }
+        if (player && typeof player.getPlayerState === 'function') {
+            out.player_state = player.getPlayerState();
+        }
+    } catch (e) { out.player_data_error = String(e); }
+
+    addVideoElementStats(out, video);
+    return out;
+}
+
+function twitchStats() {
+    const video = document.querySelector('video');
+    if (!video) { return {platform: 'twitch', error: 'no_video'}; }
+
+    const out = {platform: 'twitch'};
+    try {
+        // Channel name from the first non-empty path segment (e.g. /channelname).
+        const seg = location.pathname.split('/').filter(Boolean);
+        out.channel = seg.length ? seg[0] : null;
+        out.is_live = true; // Twitch watch pages are live unless it's a VOD (/videos/).
+        if (location.pathname.startsWith('/videos/')) {
+            out.is_live = false;
+            out.video_id = seg.length > 1 ? seg[1] : null;
+        }
+    } catch (e) { out.page_data_error = String(e); }
+
+    addVideoElementStats(out, video);
+    return out;
+}
+
+function addVideoElementStats(out, video) {
+    try {
+        if (!video) { return; }
+        out.video_width = video.videoWidth;
+        out.video_height = video.videoHeight;
+        out.resolution = video.videoWidth + 'x' + video.videoHeight;
+        out.playback_rate = video.playbackRate;
+        out.paused = video.paused;
+        out.muted = video.muted;
+        out.volume = video.volume;
+        out.current_time_secs = out.current_time_secs != null
+            ? out.current_time_secs : video.currentTime;
+        // Buffer-ahead: how many seconds are buffered past the current position.
+        if (video.buffered && video.buffered.length) {
+            const end = video.buffered.end(video.buffered.length - 1);
+            out.buffer_ahead_secs = Math.max(0, end - video.currentTime);
+        }
+        if (typeof video.getVideoPlaybackQuality === 'function') {
+            const q = video.getVideoPlaybackQuality();
+            out.dropped_video_frames = q.droppedVideoFrames;
+            out.total_video_frames = q.totalVideoFrames;
+            if ('corruptedVideoFrames' in q) {
+                out.corrupted_video_frames = q.corruptedVideoFrames;
+            }
+        }
+    } catch (e) { out.video_element_error = String(e); }
+}
+
+if (host.indexOf('youtube.com') !== -1 || host.indexOf('youtu.be') !== -1) {
+    return youtubeStats();
+}
+if (host.indexOf('twitch.tv') !== -1) {
+    return twitchStats();
+}
+// Fallback: try whatever <video> is on the page.
+const video = document.querySelector('video');
+if (!video) { return {platform: 'unknown', error: 'no_video'}; }
+const out = {platform: 'unknown'};
+addVideoElementStats(out, video);
+return out;
+"""
+
+
+class VideoStatsLogger:
+    """Samples video-player stats on a background thread into a JSONL file.
+
+    Site-aware: works on YouTube ("Stats for Nerds") and Twitch (HTMLVideoElement
+    metrics). The platform is detected per-sample from the page, so a single
+    logger handles a session that navigates between sites.
+    """
+
+    def __init__(self, driver, out_path: str = "netgent_video_stats.jsonl",
+                 interval: float = 2.0):
+        self.driver = driver
+        self.out_path = out_path
+        self.interval = interval
+        self._thread = None
+        self._stop_event = threading.Event()
+
+    def configure(self, out_path: str = None, interval: float = None):
+        """Update output path / interval before starting."""
+        if out_path is not None:
+            self.out_path = out_path
+        if interval is not None:
+            self.interval = interval
+
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def sample(self) -> dict:
+        """Capture a single stats snapshot (stamped with time and URL)."""
+        sample = {"timestamp": time.time()}
+        try:
+            sample["url"] = self.driver.current_url
+        except Exception:
+            sample["url"] = None
+        try:
+            stats = self.driver.execute_script(_STATS_JS)
+            sample["stats"] = stats
+        except Exception as e:
+            sample["stats"] = None
+            sample["sample_error"] = str(e)
+        return sample
+
+    def _run(self):
+        # Line-buffered append so each sample is flushed to disk immediately.
+        with open(self.out_path, "a", buffering=1) as f:
+            while not self._stop_event.is_set():
+                sample = self.sample()
+                try:
+                    f.write(json.dumps(sample) + "\n")
+                except Exception as e:
+                    logger.warning(f"Failed to write stats sample: {e}")
+                # Wait the interval, but wake immediately on stop().
+                self._stop_event.wait(self.interval)
+
+    def start(self):
+        if self.is_running():
+            logger.info("Stats logger already running; ignoring start()")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True,
+                                        name="video-stats-logger")
+        self._thread.start()
+        logger.info(f"Video stats logging started -> {self.out_path} "
+                    f"(every {self.interval}s)")
+
+    def stop(self):
+        if not self.is_running():
+            return
+        self._stop_event.set()
+        self._thread.join(timeout=self.interval + 5)
+        logger.info(f"Video stats logging stopped -> {self.out_path}")
+        self._thread = None
+
+
+# Backwards-compatible alias (the logger now covers Twitch as well as YouTube).
+YouTubeStatsLogger = VideoStatsLogger


### PR DESCRIPTION
Issue #21 

## Summary

Enables running **multiple application workflows at the same time** in a single container/invocation — e.g. watch YouTube while also streaming Twitch and running a `wget` download. This is purely about *executing* one or more pre-built workflows in parallel; it is separate from generating workflows with AI.

The container entrypoint (`scripts/start.sh`) becomes a multi-workflow orchestrator with two auto-detected modes:

- **Legacy single-workflow mode** (`-e` / `-g`): unchanged, fully backward compatible — existing commands behave exactly as before.
- **Multi-workflow mode**: pass one or more workflow files, classified by extension and run concurrently:
  - `*.json` → a NetGent executable workflow. Each gets its **own Xvfb display, its own Chrome profile, and (with `-s`) its own noVNC port**, so the `pyautogui` cursors and browser profiles never collide.
  - `*.sh` → an arbitrary bash workflow (`wget`, `ping`, …). No display.

## Why

`PyAutoGUIController` drives clicks/keystrokes through the OS cursor of a single X display, which is a global resource — two browser workflows on one display would fight over the cursor. The orchestrator isolates each browser workflow on its own display + Chrome profile, which is what makes true concurrency safe.

## Behavior

- **Isolation:** each browser workflow runs on its own display (`:99`, `:100`, …) and Chrome profile. A failure in one workflow does not stop the others.
- **Live viewing:** with `-s`, each browser workflow gets its own noVNC port, assigned sequentially from `8080` (1st → `:8080`, 2nd → `:8081`, …) — watch each in its own tab, just like the single-workflow view.
- **Output:** per-workflow results and logs are isolated under `out/<workflow-name>/`.
- **Completion:** the run finishes once **all** workflows complete.

## Usage

### Docker
```bash
docker run --platform=linux/amd64 --rm -d \
  -p 8080:8080 -p 8081:8081 \
  -v "$PWD/examples/web_browsing/youtube/results/youtube_stats_result.json:/youtube.json:ro" \
  -v "$PWD/examples/web_browsing/twitch-watch/results/twitch-stats_result.json:/twitch.json:ro" \
  -v "$PWD/examples/bash_workflows/wget-download.sh:/wget.sh:ro" \
  -v "$PWD/out:/out" \
  netgent \
  /youtube.json /twitch.json /wget.sh -s

CLI (inside the container)

start-netgent /youtube.json /twitch.json /wget.sh -s

Changes

- scripts/start.sh — refactored into a multi-workflow orchestrator (per-display VNC setup extracted into a reusable function; legacy mode preserved).
- examples/bash_workflows/ — added wget-download.sh and ping.sh as runnable .sh examples.
- README.md — added a "Running Multiple Applications Concurrently" section (CLI + Docker).

Testing

Rebuilt the image and ran the YouTube + Twitch QoE workflows concurrently with -s:

- ✅ Both workflows launched concurrently on separate displays (:99, :100).
- ✅ Independent noVNC viewers live on :8080 and :8081 (both HTTP 200).
- ✅ Separate Chrome profiles — no profile-lock conflicts.
- ✅ YouTube ran end to end: navigated, detected #movie_player, logged 190 QoE samples to out/youtube/youtube_stats.jsonl.
- ✅ Output isolation under out/<workflow-name>/.