### PR TITLE
Fix apt-get hash sum mismatch during Docker build on Apple Silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ENV DISPLAY=:99 \
 WORKDIR /home/agent/app
 
 # System deps (Xvfb, VNC, noVNC needs), Chrome dependencies, SSH (optional)
+RUN echo 'Acquire::http::Pipeline-Depth "0";' > /etc/apt/apt.conf.d/99fixbadproxy && \
+       echo 'Acquire::http::No-Cache "true";' >> /etc/apt/apt.conf.d/99fixbadproxy && \
+       echo 'Acquire::BrokenProxy "true";' >> /etc/apt/apt.conf.d/99fixbadproxy && \
+       echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/99fixbadproxy
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl wget unzip git xauth \
     xvfb x11vnc fluxbox \


### PR DESCRIPTION
Adds apt config to disable pipelining and force retries, working
  around package corruption from QEMU emulation when building
  linux/amd64 images on Apple Silicon Macs.

 ## Fix
   Added an apt config file (`99fixbadproxy`) before the install step that:
   - disables HTTP pipelining
   - disables HTTP caching
   - treats the proxy as broken
   - retries failed downloads up to 5 times


  Verified the image builds successfully and runs correctly on an Apple
   Silicon Mac with this change